### PR TITLE
Fix compartment mismatch

### DIFF
--- a/src/js_dbg_engine.cpp
+++ b/src/js_dbg_engine.cpp
@@ -554,7 +554,7 @@ int JSDebuggerEngine::registerDebuggee( const JS::HandleObject debuggee ) {
 
     // After registering the debuggee object it will be rooted by
     // the debugger itself, so it's not needed to root it here.
-    RootedValue wrappedDebuggeeValue( _ctx, ObjectValue( *debuggee ) );
+    RootedValue wrappedDebuggeeValue( _ctx, ObjectValue( *wrappedDebuggee ) );
     Value argv[] = { wrappedDebuggeeValue };
     Value result;
     if( !JS_CallFunctionName( _ctx, _debuggerModule, "addDebuggee", 1, argv, &result ) ) {


### PR DESCRIPTION
Fixed an issue where I would get a compartment mismatch assertion triggered in SpiderMonkey. This only happens when I run the tests against a debug build of libmozjs-24.so on Linux and Windows.

``` bash
~/src/jsrdbg/check(master ✔) ./jsrdbg_check
[INFO]: Starting unit tests.
*** Compartment mismatch 0x1ec62c0 vs. 0x1f3b930
[1]    26973 segmentation fault (core dumped)  ./jsrdbg_check
```

With this change the tests don't show a compartment mismatch.
