### PR TITLE
initialization constructor changed to open, due to the missing move c…

### DIFF
--- a/utils/log.cpp
+++ b/utils/log.cpp
@@ -124,7 +124,7 @@ public:
     FileLogger() : _fstreamMutex(), _out() {
         const char *file_path = getenv("JSRDBG_LOG_FILE_PATH");
         if (file_path) {
-            _out = std::ofstream(file_path, std::ofstream::out | std::ios::binary);
+            _out.open(file_path, std::ofstream::out | std::ios::binary);
         }
     };
 


### PR DESCRIPTION
…onstructor in gcc 4.9

Benjamin, could you please test it on windows?