### PR TITLE
Add step-out command

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ env - Prints environment variables
 pc - Prints information about current frame
 step - Steps to a next instruction
 next - Steps to a next instructions going through subroutines
+finish - Finishes the execution of the current function body
 continue - Continues execution of the program being debugged
 stop - Terminates a debuggee.
 break,pause - Pauses the program being debugged or sets breakpoints
@@ -679,6 +680,16 @@ Standard parameters described above have been omitted intentionally.
     Response: None.
 
     Req: {"type":"command","name":"step"}
+
+    ----
+
+    Name: step_out
+    Description: Finishes the execution of the current function body.
+    Request:
+        name - 'step_out'
+    Response: None.
+
+    Req: {"type":"command", "name": "step_out"}
 
     ----
 

--- a/jrdb/js/mozjs_dbg_client.js
+++ b/jrdb/js/mozjs_dbg_client.js
@@ -56,7 +56,13 @@
         "Usage:\n"+
         "step\n"+
         "s";
-        
+
+    const HELP_FINISH = "" +
+        "Finishes the execution of the current function body\n"+
+        "Usage:\n"+
+        "finish\n"+
+        "f";
+
     const HELP_NEXT = ""+
         "Steps program proceeding through subroutines. It doesn't enter\n"+
         "subroutine calls but executes them instead and pauses in the line just\n"+
@@ -184,6 +190,7 @@
         "pc - Prints information about current frame\n"+
         "step - Steps to a next instruction\n"+
         "next - Steps to a next instructions going through subroutines\n"+
+        "finish - Finishes the execution of the current function body\n"+
         "continue - Continues execution of the program being debugged\n"+
         "break,pause - Pauses the program being debugged or sets breakpoints\n"+
         "delete - Deletes breakpoints\n"+
@@ -795,6 +802,12 @@
                 fn: function( command ) {
                     env.sendCommand( protocolStrategy.getStep() );
                 }
+            },            {
+                alias: ['finish', 'f'],
+                help: HELP_FINISH,
+                fn: function( command ) {
+                    env.sendCommand( protocolStrategy.getFinish() );
+                }
             },
             {
                 alias: ['next','n'],
@@ -1074,6 +1087,13 @@
             return {
                 type: 'command',
                 name: 'step'
+            };
+        },
+        // finishes continuation of the current function body
+        getFinish: function() {
+            return {
+                type: 'command',
+                name: 'step_out'
             };
         },
         // Gets all contexts managed by the remote debuggger.

--- a/src/js/mozjs_dbg.js
+++ b/src/js/mozjs_dbg.js
@@ -1458,9 +1458,11 @@
                 fn: function(ctx) {
                     var frame  = ctx.debuggerMediator.
                                         getPC().getFrame();
-                    frame.older.onStep = function() {
+                    var stop_function = function() {
                         ctx.debuggerMediator.pause();
                     };
+                    frame.older ? frame.older.onStep = stop_function :
+                                  frame.onPop = stop_function;
                     return HC_RES_CONTINUE;
                  }
             },

--- a/src/js/mozjs_dbg.js
+++ b/src/js/mozjs_dbg.js
@@ -1451,6 +1451,21 @@
             },
 
             /**
+             * finishes the continuation of the current function body
+             */
+            'step_out': {
+                needPause: true,
+                fn: function(ctx) {
+                    var frame  = ctx.debuggerMediator.
+                                        getPC().getFrame();
+                    frame.older.onStep = function() {
+                        ctx.debuggerMediator.pause();
+                    };
+                    return HC_RES_CONTINUE;
+                 }
+            },
+
+            /**
              * Steps to the next line proceeding through subroutines.
              */
             'next': {


### PR DESCRIPTION
This pull request adds a new command: step_out

step_out behaves much like gdb's finish.

This addition is useful, because step_out is a common feature of most debugger clients, e.g., VS Code.