### PR TITLE
Add server version command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ fix/fixnostack
 *.swo
 *.swn
 
+# generated files
+src/version.h
+
+# MSVS
+win/.jsrdbg.vcxproj.un~
+win/jsrdbg.vcxproj~

--- a/README.md
+++ b/README.md
@@ -950,6 +950,17 @@ Standard parameters described above have been omitted intentionally.
 
     ----
 
+    Name: server_version
+    Description: Gets the version of the remote debugger.
+    Request: Plain string: server_version\n
+    Response:
+        subtype  - 'server_version'
+        version - String representing the git tag, commit etc.
+
+    Res: {"type":"info","subtype":"server_version","version":"0.0.7-16-gd6de3b3"}
+
+    ----
+
     Name: exit
     Description: Closes debugger.
     Request: Plain string: exit\n

--- a/configure.ac
+++ b/configure.ac
@@ -100,5 +100,11 @@ check/js/Makefile
 check/Makefile
 ])
 
+#generate Version header
+echo "#ifndef VERSION_H" > src/version.h
+echo "#define VERSION_H" >> src/version.h
+echo "#define JSRDBG_VERSION \"$(git describe --abbrev=4 --dirty --always --tags)\"" >> src/version.h
+echo "#endif" >> src/version.h
+
 AC_OUTPUT
 

--- a/jrdb/js/mozjs_dbg_client.js
+++ b/jrdb/js/mozjs_dbg_client.js
@@ -24,6 +24,9 @@
     const HELP_VERSION = ""+
         "Shows application version.";
 
+   const HELP_SERVER_VERSION = ""+
+        "Shows the version of the remote debugger";
+
     const HELP_DELETE = ""+
         "Arguments are breakpoint numbers with spaces in between.\n"+
         "To delete all breakpoints, give no argument.\n"+
@@ -199,6 +202,7 @@
         "backtrace - Prints backtrace of stack frames\n"+
         "print - Evaluates expressions\n"+
         "version - Shows application version\n"+
+        "server_version - Shows the version of the remote debugger\n"+
         "source - Loads script source code\n"+
         "animation - Enables/disables stepping animation";
         
@@ -552,7 +556,9 @@
         },
         
         info: {
-        
+            server_version: function(packet){
+                env.println("server version: " + packet.version);
+            },
             /* Prints list of available contexts. */
             contexts_list: function( packet ) {
                 var contexts = "Available JSContext instances: \n";
@@ -737,6 +743,13 @@
                 fn: function( command ) {
                     env.println('Client version: ' + env.packageVersion  + " Built for SpiderMonkey: " 
                                 + env.engineMajorVersion + "." + env.engineMinorVersion);
+                }
+            },
+            {
+                alias: ['server_version'],
+                help: HELP_SERVER_VERSION,
+                fn: function( command ){
+                    env.sendCommand( protocolStrategy.getServerVersion());
                 }
             },
             { 
@@ -1074,6 +1087,10 @@
     }
     
     ProtocolStrategy.prototype = {
+
+        getServerVersion: function(){
+            return "server_version";
+        },
         // Gets current PC from the server.
         getPC: function( source ) {
             return {

--- a/scripts/generate_version_h.bat
+++ b/scripts/generate_version_h.bat
@@ -1,0 +1,7 @@
+echo #ifndef VERSION_H  > ..\src\version.h
+set "tempFile=%tmp%\bat~%RANDOM%.bat"
+git -C .. describe --tags --always --dirty >> %tempFile%
+set /P GitVersion=<%tempFile%
+echo #define VERSION_H >> ..\src\version.h
+echo #define JSRDBG_VERSION "%GitVersion%" >> ..\src\version.h
+echo #endif >> ..\src\version.h

--- a/src/js_remote_dbg.cpp
+++ b/src/js_remote_dbg.cpp
@@ -28,6 +28,7 @@
 #include <encoding.hpp>
 
 #include "message_builder.hpp"
+#include "version.h"
 
 using namespace JSR;
 using namespace JS;
@@ -322,6 +323,14 @@ void SpiderMonkeyDebugger::handle( command_queue &queue, int signal ) {
 
             // Gets list of all available contexts.
             sendContextsList( clientId );
+
+        } else if (value == "server_version") {
+            // send the sever version
+            // the sever version is stored in a macro generated via the
+            // buildsystem
+            Command command( clientId, -1, MessageFactory::getInstance()->prepareServerVersion( JSRDBG_VERSION ) );
+
+            _clientManager.sendCommand( command );
 
         } else {
 

--- a/src/message_builder.cpp
+++ b/src/message_builder.cpp
@@ -53,6 +53,17 @@ std::string MessageFactory::prepareContextList( const std::vector<JSContextState
     return ss.str();
 }
 
+string MessageFactory::prepareServerVersion( const std::string &version ) {
+    stringstream ss;
+
+    ss  << "{\"type\":\"info\",\"subtype\":\"server_version\","
+        << "\"version\":\""
+        << version
+        << "\"}";
+
+    return ss.str();
+}
+
 string MessageFactory::prepareErrorMessage( ErrorCode errorCode, const string &msg ) {
     stringstream ss;
     ss << "{\"type\":\"error\",\"code\":" << errorCode << ",\"message\":\"" << msg << "\"}";

--- a/src/message_builder.hpp
+++ b/src/message_builder.hpp
@@ -45,6 +45,7 @@ public:
     };
     static MessageFactory *getInstance();
     std::string prepareContextList( const std::vector<JSContextState> &ctxList );
+    std::string prepareServerVersion( const std::string &version);
     std::string prepareErrorMessage( ErrorCode errorCode, const std::string &msg );
     std::string prepareWarningMessage( WarnCode warnCode, const std::string &msg );
 private:

--- a/win/jsrdbg.sln
+++ b/win/jsrdbg.sln
@@ -30,7 +30,8 @@ Global
 		{1C36632F-10EF-41EF-A724-6943B1E4E832}.Debug|x64.Build.0 = Debug|x64
 		{1C36632F-10EF-41EF-A724-6943B1E4E832}.Release|Win32.ActiveCfg = Release|Win32
 		{1C36632F-10EF-41EF-A724-6943B1E4E832}.Release|Win32.Build.0 = Release|Win32
-		{1C36632F-10EF-41EF-A724-6943B1E4E832}.Release|x64.ActiveCfg = Release|Win32
+		{1C36632F-10EF-41EF-A724-6943B1E4E832}.Release|x64.ActiveCfg = Release|x64
+		{1C36632F-10EF-41EF-A724-6943B1E4E832}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/win/jsrdbg.vcxproj
+++ b/win/jsrdbg.vcxproj
@@ -115,6 +115,10 @@
     <OutDir>$(SolutionDir)\$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
+  <PropertyGroup>
+    <CustomBuildBeforeTargets>GitVersionTarget</CustomBuildBeforeTargets>
+    <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -182,4 +186,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ItemDefinitionGroup>
+    <CustomBuildStep>
+      <Command>$(ProjectDir)..\scripts\generate_version_h</Command>
+      <Outputs>$(ProjectDir)..\src\version.h</Outputs>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Add a server version command, that displays the version of the remote debugger.

That is usefull, because it provides an easy method to check if a potential problem is
caused by a too old remote debugger.

Now the cofigure script on linux and a prebuild-step in MS Visual Studio generate a file
named src/version.h containing a macro called JSRDBG_VERSION. This macro is defined by
the output of 'git describe --tags --always --dirty'.

Solves issue #13 